### PR TITLE
Minor improvements

### DIFF
--- a/Example/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "53F233052D31511E00264B36"
+               BuildableName = "Example.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53F233052D31511E00264B36"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53F233052D31511E00264B36"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SnappTheming/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationConfiguration.swift
@@ -1,0 +1,16 @@
+//
+//  SnappThemingAnimationConfiguration.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+
+/// Configuration for theming animations.
+///
+/// This struct holds fallback data for Lottie animations in case no specific animation is provided.
+public struct SnappThemingAnimationConfiguration {
+    /// The fallback Lottie animation data used when no valid animation is available.
+    public let fallbackLottieAnimationData: Data
+}

--- a/SnappTheming/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationDeclarations.swift
@@ -11,14 +11,6 @@ import OSLog
 /// A type alias for theming animation declarations, mapping animations to their representations and configurations.
 public typealias SnappThemingAnimationDeclarations = SnappThemingDeclarations<SnappThemingAnimationRepresentation, SnappThemingAnimationConfiguration>
 
-/// Configuration for theming animations.
-///
-/// This struct holds fallback data for Lottie animations in case no specific animation is provided.
-public struct SnappThemingAnimationConfiguration {
-    /// The fallback Lottie animation data used when no valid animation is available.
-    public let fallbackLottieAnimationData: Data
-}
-
 extension SnappThemingAnimationDeclarations where DeclaredValue == SnappThemingAnimationRepresentation, Configuration == SnappThemingAnimationConfiguration {
     /// Initializes animation declarations with caching and configuration options.
     ///
@@ -29,7 +21,7 @@ extension SnappThemingAnimationDeclarations where DeclaredValue == SnappThemingA
         self.init(
             cache: cache,
             rootKey: .animations,
-            configuration: .init(
+            configuration: Configuration(
                 fallbackLottieAnimationData: configuration.fallbackLottieAnimationData
             )
         )

--- a/SnappTheming/Sources/SnappTheming/Theme/Buttons/InteractiveColor/SnappThemingInteractiveColorDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Buttons/InteractiveColor/SnappThemingInteractiveColorDeclarations.swift
@@ -22,7 +22,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingInteractiv
         self.init(
             cache: cache,
             rootKey: .interactiveColors,
-            configuration: .init(
+            configuration: Configuration(
                 fallbackColor: configuration.fallbackInteractiveColor,
                 colorFormat: configuration.colorFormat,
                 themeConfiguration: configuration

--- a/SnappTheming/Sources/SnappTheming/Theme/Buttons/SnappThemingButtonStyle.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Buttons/SnappThemingButtonStyle.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 public struct SnappThemingButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
     public let surfaceColor: SnappThemingInteractiveColor
     public let textColor: SnappThemingInteractiveColor
     public let borderColor: SnappThemingInteractiveColor
@@ -31,8 +33,6 @@ public struct SnappThemingButtonStyle: ButtonStyle {
         self.shape = shape
         self.font = font
     }
-
-    @Environment(\.isEnabled) private var isEnabled
 
     public func makeBody(configuration: Configuration) -> some View {
         let shape = shape.value

--- a/SnappTheming/Sources/SnappTheming/Theme/Buttons/SnappThemingButtonStyleRepresentation.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Buttons/SnappThemingButtonStyleRepresentation.swift
@@ -44,19 +44,19 @@ public struct SnappThemingButtonStyleRepresentation: Codable {
 
         do {
             if let singleSurfaceColor = try? container.decode(SnappThemingToken<SnappThemingColorRepresentation>.self, forKey: .surfaceColor) {
-                self.surfaceColor = .init(from: singleSurfaceColor)
+                self.surfaceColor = SnappThemingToken(from: singleSurfaceColor)
             } else {
                 self.surfaceColor = try container.decode(SnappThemingToken<SnappThemingInteractiveColorInformation>.self, forKey: .surfaceColor)
             }
 
             if let singleTextColor = try? container.decode(SnappThemingToken<SnappThemingColorRepresentation>.self, forKey: .textColor) {
-                self.textColor = .init(from: singleTextColor)
+                self.textColor = SnappThemingToken(from: singleTextColor)
             } else {
                 self.textColor = try container.decode(SnappThemingToken<SnappThemingInteractiveColorInformation>.self, forKey: .textColor)
             }
 
             if let singleBorderColor = try? container.decode(SnappThemingToken<SnappThemingColorRepresentation>.self, forKey: .borderColor) {
-                self.borderColor = .init(from: singleBorderColor)
+                self.borderColor = SnappThemingToken(from: singleBorderColor)
             } else {
                 self.borderColor = try container.decode(SnappThemingToken<SnappThemingInteractiveColorInformation>.self, forKey: .borderColor)
             }
@@ -104,7 +104,7 @@ public extension SnappThemingButtonStyleRepresentation {
             borderColor: resolvedBorderColor,
             borderWidth: resolvedBorderWidth,
             shape: resolvedShape,
-            typography: .init(resolvedFont.resolver, fontSize: resolvedFontSize.cgFloat)
+            typography: SnappThemingTypographyResolver(resolvedFont.resolver, fontSize: resolvedFontSize.cgFloat)
 
         )
     }

--- a/SnappTheming/Sources/SnappTheming/Theme/Color/SnappThemingColorConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Color/SnappThemingColorConfiguration.swift
@@ -1,0 +1,26 @@
+//
+//  SnappThemingColorConfiguration.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+
+/// A structure representing the configuration for theming colors in the Snapp application.
+///
+/// - `fallbackColor`: The default color to use if no matching color is found in the configuration.
+/// - `colorFormat`: Specifies the format in which colors are represented (e.g., hex, dynamic, etc.).
+///
+/// This structure is designed to help configure colors that will be used across the app, with a fallback in case of missing or incorrect values.
+public struct SnappThemingColorConfiguration {
+    /// The default color to fall back to when a color is not available in the theme.
+    public let fallbackColor: Color
+    /// A `UIColor` representation of the `fallbackColor`.
+    public var fallbackUIColor: UIColor { UIColor(fallbackColor) }
+
+    /// The format of the color (ARGB or RGBA).
+    public let colorFormat: SnappThemingColorFormat
+}

--- a/SnappTheming/Sources/SnappTheming/Theme/Color/SnappThemingColorDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Color/SnappThemingColorDeclarations.swift
@@ -7,25 +7,10 @@
 
 import Foundation
 import SwiftUI
+import UIKit
 
 /// Responsible for managing and resolving color tokens. This includes static colors and dynamic system colors, supporting light/dark mode.
 public typealias SnappThemingColorDeclarations = SnappThemingDeclarations<SnappThemingColorRepresentation, SnappThemingColorConfiguration>
-
-/// A structure representing the configuration for theming colors in the Snapp application.
-///
-/// - `fallbackColor`: The default color to use if no matching color is found in the configuration.
-/// - `colorFormat`: Specifies the format in which colors are represented (e.g., hex, dynamic, etc.).
-///
-/// This structure is designed to help configure colors that will be used across the app, with a fallback in case of missing or incorrect values.
-public struct SnappThemingColorConfiguration {
-    /// The default color to fall back to when a color is not available in the theme.
-    public let fallbackColor: Color
-    /// A `UIColor` representation of the `fallbackColor`.
-    public var fallbackUIColor: UIColor { UIColor(fallbackColor) }
-
-    /// The format of the color (ARGB or RGBA).
-    public let colorFormat: SnappThemingColorFormat
-}
 
 extension SnappThemingDeclarations where DeclaredValue == SnappThemingColorRepresentation, Configuration == SnappThemingColorConfiguration {
     /// Initializes a `SnappThemingDeclarations` object for colors, optionally using a cached color representation.
@@ -35,11 +20,11 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingColorRepre
     ///   - configuration: A configuration object that defines the fallback color and color format. Defaults to `.default`.
     ///
     /// - This initializer allows the creation of color declarations using pre-defined fallback values and color format configuration.
-    public init(cache: [String: SnappThemingToken<SnappThemingColorRepresentation>]?, configuration: SnappThemingParserConfiguration = .default) {
+    public init(cache: [String: SnappThemingToken<DeclaredValue>]?, configuration: SnappThemingParserConfiguration = .default) {
         self.init(
             cache: cache,
             rootKey: .colors,
-            configuration: .init(
+            configuration: Configuration(
                 fallbackColor: configuration.fallbackColor,
                 colorFormat: configuration.colorFormat
             )
@@ -51,7 +36,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingColorRepre
     /// - Parameter keyPath: The key path of the color to fetch.
     /// - Returns: The corresponding color value if found, or the `fallbackColor` if not found.
     public subscript(dynamicMember keyPath: String) -> Color {
-        guard let representation: SnappThemingColorRepresentation = self[dynamicMember: keyPath] else {
+        guard let representation: DeclaredValue = self[dynamicMember: keyPath] else {
             return configuration.fallbackColor
         }
         return representation.color(using: configuration.colorFormat)
@@ -62,29 +47,9 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingColorRepre
     /// - Parameter keyPath: The key path of the color to fetch.
     /// - Returns: The corresponding `UIColor` value if found, or `.clear` if not found.
     public subscript(dynamicMember keyPath: String) -> UIColor {
-        guard let representation: SnappThemingColorRepresentation = self[dynamicMember: keyPath] else {
+        guard let representation: DeclaredValue = self[dynamicMember: keyPath] else {
             return configuration.fallbackUIColor
         }
         return representation.uiColor(using: configuration.colorFormat)
-    }
-}
-
-extension SnappThemingColorRepresentation {
-    func color(using format: SnappThemingColorFormat) -> Color {
-        switch self {
-        case let .dynamic(dynamicColor):
-            dynamicColor.color(using: format)
-        case let .hex(hexValue):
-            Color(hex: hexValue, format: format)
-        }
-    }
-
-    func uiColor(using format: SnappThemingColorFormat) -> UIColor {
-        switch self {
-        case let .dynamic(dynamicColor):
-            dynamicColor.uiColor(using: format)
-        case let .hex(hexValue):
-            UIColor(hex: hexValue, format: format)
-        }
     }
 }

--- a/SnappTheming/Sources/SnappTheming/Theme/Color/SnappThemingColorRepresentation.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Color/SnappThemingColorRepresentation.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import SwiftUI
+import UIKit
 
 /// A representation of color in the SnappTheming framework.
 public enum SnappThemingColorRepresentation: Codable {
@@ -35,6 +37,26 @@ public enum SnappThemingColorRepresentation: Codable {
             try container.encode(value)
         case .dynamic(let value):
             try container.encode(value)
+        }
+    }
+}
+
+extension SnappThemingColorRepresentation {
+    func color(using format: SnappThemingColorFormat) -> Color {
+        switch self {
+        case let .dynamic(dynamicColor):
+            dynamicColor.color(using: format)
+        case let .hex(hexValue):
+            Color(hex: hexValue, format: format)
+        }
+    }
+
+    func uiColor(using format: SnappThemingColorFormat) -> UIColor {
+        switch self {
+        case let .dynamic(dynamicColor):
+            dynamicColor.uiColor(using: format)
+        case let .hex(hexValue):
+            UIColor(hex: hexValue, format: format)
         }
     }
 }

--- a/SnappTheming/Sources/SnappTheming/Theme/Font/SnappThemingFontDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Font/SnappThemingFontDeclarations.swift
@@ -13,12 +13,12 @@ import CoreText
 public typealias SnappThemingFontDeclarations = SnappThemingDeclarations<SnappThemingFontInformation, Void>
 
 extension SnappThemingDeclarations where DeclaredValue == SnappThemingFontInformation, Configuration == Void {
-    public init(cache: [String: SnappThemingToken<SnappThemingFontInformation>]?, configuration: SnappThemingParserConfiguration = .default) {
+    public init(cache: [String: SnappThemingToken<DeclaredValue>]?, configuration: SnappThemingParserConfiguration = .default) {
         self.init(cache: cache, rootKey: .fonts)
     }
 
     public subscript(dynamicMember keyPath: String) -> SnappThemingFontResolver {
-        guard let representation: SnappThemingFontInformation = self[dynamicMember: keyPath] else {
+        guard let representation: DeclaredValue = self[dynamicMember: keyPath] else {
             return .system
         }
         return representation.resolver

--- a/SnappTheming/Sources/SnappTheming/Theme/Font/SnappThemingFontManager.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Font/SnappThemingFontManager.swift
@@ -1,0 +1,14 @@
+//
+//  SnappThemingFontManager.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+
+public protocol SnappThemingFontManager {
+    func registerFonts(_ fonts: [SnappThemingFontInformation])
+    func unregisterFonts(_ fonts: [SnappThemingFontInformation])
+    func registerFont(_ font: SnappThemingFontInformation)
+}

--- a/SnappTheming/Sources/SnappTheming/Theme/Font/SnappThemingFontManagerDefault.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Font/SnappThemingFontManagerDefault.swift
@@ -9,14 +9,8 @@ import Foundation
 import CoreText
 import OSLog
 
-public protocol SnappThemingFontManager {
-    func registerFonts(_ fonts: [SnappThemingFontInformation])
-    func unregisterFonts(_ fonts: [SnappThemingFontInformation])
-    func registerFont(_ font: SnappThemingFontInformation)
-}
-
 /// An enumeration of possible errors in `SnappThemingFontManager`.
-enum SnappThemingFontManagerError: Error {
+fileprivate enum SnappThemingFontManagerError: Error {
     /// Indicates that the font registration failed at the specified URL.
     case failedToRegisterFont(at: URL)
 }

--- a/SnappTheming/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientConfiguration.swift
@@ -1,0 +1,15 @@
+//
+//  SnappThemingGradientConfiguration.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+import SwiftUI
+
+/// Configuration for resolving gradients in the theming system.
+public struct SnappThemingGradientConfiguration {
+    /// The fallback color to use when a specific gradient cannot be resolved.
+    public let fallbackShapeStyle: Color
+}

--- a/SnappTheming/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientDeclarations.swift
@@ -10,23 +10,17 @@ import SwiftUI
 /// Manages gradient tokens, including support for linear, radial, and angular gradients, enabling the creation of dynamic and visually appealing shape backgrounds.
 public typealias SnappThemingGradientDeclarations = SnappThemingDeclarations<SnappThemingGradientRepresentation, SnappThemingGradientConfiguration>
 
-/// Configuration for resolving gradients in the theming system.
-public struct SnappThemingGradientConfiguration {
-    /// The fallback color to use when a specific gradient cannot be resolved.
-    public let fallbackShapeStyle: Color
-}
-
 extension SnappThemingDeclarations where DeclaredValue == SnappThemingGradientRepresentation, Configuration == SnappThemingGradientConfiguration {
     /// Initializes the declarations for resolving shape styles in the theming system.
     ///
     /// - Parameters:
     ///   - cache: An optional cache of theming tokens for shape styles.
     ///   - configuration: The parser configuration, defaulting to `.default`.
-    public init(cache: [String: SnappThemingToken<SnappThemingGradientRepresentation>]?, configuration: SnappThemingParserConfiguration = .default) {
+    public init(cache: [String: SnappThemingToken<DeclaredValue>]?, configuration: SnappThemingParserConfiguration = .default) {
         self.init(
             cache: cache,
             rootKey: .gradients,
-            configuration: .init(
+            configuration: Configuration(
                 fallbackShapeStyle: configuration.fallbackColor
             )
         )

--- a/SnappTheming/Sources/SnappTheming/Theme/Image/SnappThemingImageConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Image/SnappThemingImageConfiguration.swift
@@ -1,0 +1,18 @@
+//
+//  SnappThemingImageConfiguration.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+import SwiftUI
+
+/// Configuration for handling themed images in a SnappTheming framework.
+public struct SnappThemingImageConfiguration {
+    /// Fallback image to use when a specific image cannot be resolved.
+    public let fallbackImage: Image
+
+    /// Manager for handling image caching and retrieval.
+    public let imagesManager: SnappThemingImageManager
+}

--- a/SnappTheming/Sources/SnappTheming/Theme/Image/SnappThemingImageDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Image/SnappThemingImageDeclarations.swift
@@ -12,25 +12,16 @@ import OSLog
 /// Manages image tokens. Supports bitmap assets for different scenarios.
 public typealias SnappThemingImageDeclarations = SnappThemingDeclarations<SnappThemingDataURI, SnappThemingImageConfiguration>
 
-/// Configuration for handling themed images in a SnappTheming framework.
-public struct SnappThemingImageConfiguration {
-    /// Fallback image to use when a specific image cannot be resolved.
-    public let fallbackImage: Image
-
-    /// Manager for handling image caching and retrieval.
-    public let imagesManager: SnappThemingImageManager
-}
-
 extension SnappThemingDeclarations where DeclaredValue == SnappThemingDataURI, Configuration == SnappThemingImageConfiguration {
     /// Initializes the declarations for themed images.
     /// - Parameters:
     ///   - cache: A cache of image tokens keyed by their identifiers.
     ///   - configuration: The parser configuration used to define fallback and manager behavior.
-    public init(cache: [String: SnappThemingToken<SnappThemingDataURI>]?, configuration: SnappThemingParserConfiguration = .default) {
+    public init(cache: [String: SnappThemingToken<DeclaredValue>]?, configuration: SnappThemingParserConfiguration = .default) {
         self.init(
             cache: cache,
             rootKey: .images,
-            configuration: SnappThemingImageConfiguration(
+            configuration: Configuration(
                 fallbackImage: configuration.fallbackImage,
                 imagesManager: configuration.imageManager ?? SnappThemingImageManagerDefault(
                     themeCacheRootURL: configuration.themeCacheRootURL,
@@ -44,7 +35,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingDataURI, C
     /// - Parameter keyPath: The key path used to identify the desired image.
     /// - Returns: The resolved image, or the fallback image if the resolution fails.
     public subscript(dynamicMember keyPath: String) -> Image {
-        guard let representation: SnappThemingDataURI = self[dynamicMember: keyPath] else {
+        guard let representation: DeclaredValue = self[dynamicMember: keyPath] else {
             os_log(.error, "Error resolving image with name: %@.", keyPath)
             return configuration.fallbackImage
         }

--- a/SnappTheming/Sources/SnappTheming/Theme/Image/SnappThemingImageManagerDefault.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Image/SnappThemingImageManagerDefault.swift
@@ -11,7 +11,7 @@ import UIKit
 import UniformTypeIdentifiers
 
 /// An enumeration of possible errors in `SnappThemingImageManager`.
-public enum ImagesManagerError: Error {
+fileprivate enum ImagesManagerError: Error {
     /// Indicates that the images directory URL is unknown or inaccessible.
     case unknownImagesDirectoryURL
 

--- a/SnappTheming/Sources/SnappTheming/Theme/Metric/SnappThemingMetricConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Metric/SnappThemingMetricConfiguration.swift
@@ -1,0 +1,14 @@
+//
+//  SnappThemingMetricConfiguration.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+
+/// Configuration for resolving metrics in the SnappTheming framework.
+public struct SnappThemingMetricConfiguration {
+    /// Fallback metric value to use when a specific metric cannot be resolved.
+    public let fallbackMetric: CGFloat
+}

--- a/SnappTheming/Sources/SnappTheming/Theme/Metric/SnappThemingMetricDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Metric/SnappThemingMetricDeclarations.swift
@@ -10,22 +10,17 @@ import Foundation
 /// Handles numeric tokens, such as spacing, corner radius, border widths. Useful for creating a consistent design language with reusable measurements.
 public typealias SnappThemingMetricDeclarations = SnappThemingDeclarations<Double, SnappThemingMetricConfiguration>
 
-/// Configuration for resolving metrics in the SnappTheming framework.
-public struct SnappThemingMetricConfiguration {
-    /// Fallback metric value to use when a specific metric cannot be resolved.
-    public let fallbackMetric: CGFloat
-}
 
 extension SnappThemingDeclarations where DeclaredValue == Double, Configuration == SnappThemingMetricConfiguration {
     /// Initializes the declarations for themed metrics.
     /// - Parameters:
     ///   - cache: A cache of metric tokens keyed by their identifiers.
     ///   - configuration: The parser configuration used to define fallback behavior.
-    public init(cache: [String: SnappThemingToken<Double>]?, configuration: SnappThemingParserConfiguration = .default) {
+    public init(cache: [String: SnappThemingToken<DeclaredValue>]?, configuration: SnappThemingParserConfiguration = .default) {
         self.init(
             cache: cache,
             rootKey: .metrics,
-            configuration: .init(
+            configuration: Configuration(
                 fallbackMetric: configuration.fallbackMetric
             )
         )
@@ -35,7 +30,7 @@ extension SnappThemingDeclarations where DeclaredValue == Double, Configuration 
     /// - Parameter keyPath: The key path used to identify the desired metric.
     /// - Returns: The resolved metric as a `CGFloat`, or the fallback metric if resolution fails.
     public subscript(dynamicMember keyPath: String) -> CGFloat {
-        guard let representation: Double = self[dynamicMember: keyPath] else {
+        guard let representation: DeclaredValue = self[dynamicMember: keyPath] else {
             return configuration.fallbackMetric
         }
         return CGFloat(representation)

--- a/SnappTheming/Sources/SnappTheming/Theme/SegmentControls/SnappThemingSegmentControlStyleConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/SegmentControls/SnappThemingSegmentControlStyleConfiguration.swift
@@ -9,6 +9,8 @@ import Foundation
 
 /// A configuration structure for defining the style of a segment control in the SnappTheming system.
 public struct SnappThemingSegmentControlStyleConfiguration {
+    //  MARK: - Public properties
+
     /// The fallback color for the surface of the segment control.
     public let fallbackSurfaceColor: SnappThemingInteractiveColor
 
@@ -27,6 +29,11 @@ public struct SnappThemingSegmentControlStyleConfiguration {
     /// The fallback style for the normal (unselected) segment of the control.
     public let fallbackNormalSegment: SnappThemingButtonStyleResolver
 
+    /// The color format used in the theming system (e.g., Hex, RGBA).
+    public let colorFormat: SnappThemingColorFormat
+
+    //  MARK: - Internal properties
+
     let metrics: SnappThemingMetricDeclarations
     let fonts: SnappThemingFontDeclarations
     let colors: SnappThemingColorDeclarations
@@ -34,9 +41,23 @@ public struct SnappThemingSegmentControlStyleConfiguration {
     let interactiveColors: SnappThemingInteractiveColorDeclarations
     let typographies: SnappThemingTypographyDeclarations
     let buttonStyles: SnappThemingButtonStyleDeclarations
-
-    /// The color format used in the theming system (e.g., Hex, RGBA).
-    public let colorFormat: SnappThemingColorFormat
-    
     let themeConfiguration: SnappThemingParserConfiguration
+
+    internal init(fallbackSurfaceColor: SnappThemingInteractiveColor, fallbackBorderColor: SnappThemingInteractiveColor, fallbackBorderWidth: Double, fallbackShape: SnappThemingShapeType, fallbackSelectedSegment: SnappThemingButtonStyleResolver, fallbackNormalSegment: SnappThemingButtonStyleResolver, metrics: SnappThemingMetricDeclarations, fonts: SnappThemingFontDeclarations, colors: SnappThemingColorDeclarations, shapes: SnappThemingShapeDeclarations, interactiveColors: SnappThemingInteractiveColorDeclarations, typographies: SnappThemingTypographyDeclarations, buttonStyles: SnappThemingButtonStyleDeclarations, colorFormat: SnappThemingColorFormat, themeConfiguration: SnappThemingParserConfiguration) {
+        self.fallbackSurfaceColor = fallbackSurfaceColor
+        self.fallbackBorderColor = fallbackBorderColor
+        self.fallbackBorderWidth = fallbackBorderWidth
+        self.fallbackShape = fallbackShape
+        self.fallbackSelectedSegment = fallbackSelectedSegment
+        self.fallbackNormalSegment = fallbackNormalSegment
+        self.metrics = metrics
+        self.fonts = fonts
+        self.colors = colors
+        self.shapes = shapes
+        self.interactiveColors = interactiveColors
+        self.typographies = typographies
+        self.buttonStyles = buttonStyles
+        self.colorFormat = colorFormat
+        self.themeConfiguration = themeConfiguration
+    }
 }

--- a/SnappTheming/Sources/SnappTheming/Theme/SegmentControls/SnappThemingSegmentControlStyleDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/SegmentControls/SnappThemingSegmentControlStyleDeclarations.swift
@@ -25,7 +25,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingSegmentCon
         self.init(
             cache: cache,
             rootKey: .segmentControlStyle,
-            configuration: SnappThemingSegmentControlStyleConfiguration(
+            configuration: Configuration(
                 fallbackSurfaceColor: configuration.fallbackButtonStyle.surfaceColor,
                 fallbackBorderColor: configuration.fallbackButtonStyle.borderColor,
                 fallbackBorderWidth: configuration.fallbackButtonStyle.borderWidth,
@@ -47,7 +47,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingSegmentCon
 
     public subscript(dynamicMember keyPath: String) -> SnappThemingSegmentControlStyleResolver {
         guard
-            let representation: SnappThemingSegmentControlStyleRepresentation = self[dynamicMember: keyPath],
+            let representation: DeclaredValue = self[dynamicMember: keyPath],
             let borderWidth = configuration.metrics.resolver
                 .resolve(representation.borderWidth),
             let padding = configuration.metrics.resolver

--- a/SnappTheming/Sources/SnappTheming/Theme/SegmentControls/SnappThemingSegmentControlStyleRepresentation.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/SegmentControls/SnappThemingSegmentControlStyleRepresentation.swift
@@ -27,12 +27,12 @@ public struct SnappThemingSegmentControlStyleRepresentation: Codable {
         self.shape = try container.decode(SnappThemingToken<SnappThemingShapeRepresentation>.self, forKey: .shape)
 
         if let singleSurfaceColor = try? container.decode(SnappThemingToken<SnappThemingColorRepresentation>.self, forKey: .surfaceColor) {
-            self.surfaceColor = .init(from: singleSurfaceColor)
+            self.surfaceColor = SnappThemingToken(from: singleSurfaceColor)
         } else {
             self.surfaceColor = try container.decode(SnappThemingToken<SnappThemingInteractiveColorInformation>.self, forKey: .surfaceColor)
         }
         if let singleBorderColor = try? container.decode(SnappThemingToken<SnappThemingColorRepresentation>.self, forKey: .borderColor) {
-            self.borderColor = .init(from: singleBorderColor)
+            self.borderColor = SnappThemingToken(from: singleBorderColor)
         } else {
             self.borderColor = try container.decode(SnappThemingToken<SnappThemingInteractiveColorInformation>.self, forKey: .borderColor)
         }

--- a/SnappTheming/Sources/SnappTheming/Theme/Shape/SnappThemingShapeDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Shape/SnappThemingShapeDeclarations.swift
@@ -11,14 +11,13 @@ import SwiftUI
 /// Manages button shape tokens, defining the appearance of button outlines, such as circular, rounded rectangle, or custom shapes.
 public typealias SnappThemingShapeDeclarations = SnappThemingDeclarations<SnappThemingShapeRepresentation, SnappThemingShapeConfiguration>
 
-extension SnappThemingDeclarations where DeclaredValue == SnappThemingShapeRepresentation,
-                             Configuration == SnappThemingShapeConfiguration
+extension SnappThemingDeclarations where DeclaredValue == SnappThemingShapeRepresentation, Configuration == SnappThemingShapeConfiguration
 {
     public init(cache: [String: SnappThemingToken<DeclaredValue>]?, configuration: SnappThemingParserConfiguration = .default) {
         self.init(
             cache: cache,
             rootKey: .shapes,
-            configuration: .init(
+            configuration: Configuration(
                 fallbackShape: configuration.fallbackButtonStyle.shape,
                 themeConfiguration: configuration
             )
@@ -27,7 +26,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingShapeRepre
 
     @ShapeBuilder
     public subscript(dynamicMember keyPath: String) -> some Shape {
-        if let representation = cache[keyPath]?.value {
+        if let representation: DeclaredValue = cache[keyPath]?.value {
             representation.resolver().shapeType.value
         } else {
             configuration.fallbackShape.styleShape

--- a/SnappTheming/Sources/SnappTheming/Theme/SliderStyle/SnappThemingSliderStyleDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/SliderStyle/SnappThemingSliderStyleDeclarations.swift
@@ -22,7 +22,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingSliderStyl
         self.init(
             cache: cache,
             rootKey: .sliderStyle,
-            configuration: SnappThemingSliderStyleConfiguration(
+            configuration: Configuration(
                 fallbackMinimumTrackTintColor: configuration.fallbackColor,
                 fallbackMaximumTrackTintColor: configuration.fallbackColor,
                 fallbackFontSize: configuration.fallbackMetric,
@@ -38,7 +38,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingSliderStyl
 
     public subscript(dynamicMember keyPath: String) -> SnappThemingSliderStyleResolver {
         guard
-            let representation: SnappThemingSliderStyleRepresentation = self[dynamicMember: keyPath],
+            let representation: DeclaredValue = self[dynamicMember: keyPath],
             let resolvedMinimumTrackTintColor = configuration.colors
                 .resolver.resolve(representation.minimumTrackTintColor)?
                 .color(using: configuration.colorFormat),

--- a/SnappTheming/Sources/SnappTheming/Theme/SnappThemingDeclaration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/SnappThemingDeclaration.swift
@@ -147,6 +147,15 @@ public struct SnappThemingDeclaration: Codable, SnappThemingOutput {
         if parserConfiguration.encodeFonts {
             try container.encode(fonts.cache, forKey: .fonts)
         }
+        try container.encode(typography.cache, forKey:  .typography)
+        try container.encode(gradients.cache, forKey:  .gradients)
+        try container.encode(buttonStyles.cache, forKey:  .buttonStyles)
+        try container.encode(interactiveColors.cache, forKey:  .interactiveColors)
+        try container.encode(shapes.cache, forKey:  .shapes)
+        try container.encode(segmentControlStyle.cache, forKey:  .segmentControlStyle)
+        try container.encode(sliderStyle.cache, forKey:  .sliderStyle)
+        try container.encode(toggleStyle.cache, forKey:  .toggleStyle)
+        try container.encode(animations.cache, forKey:  .animations)
     }
 }
 
@@ -156,18 +165,18 @@ extension SnappThemingDeclaration {
         using configuration: SnappThemingParserConfiguration = .default
     ) -> SnappThemingDeclaration {
         SnappThemingDeclaration(imageCache: images.cache.override(other.images.cache),
-                             colorCache: colors.cache.override(other.colors.cache),
-                             metricsCache: metrics.cache.override(other.metrics.cache),
-                             fontsCache: fonts.cache.override(other.fonts.cache),
-                             typographyCache: typography.cache.override(other.typography.cache),
-                             interactiveColorsCache: interactiveColors.cache.override(other.interactiveColors.cache),
-                             buttonStylesCache: buttonStyles.cache.override(other.buttonStyles.cache),
-                             shapeInformation: shapes.cache.override(other.shapes.cache),
-                             gradientsCache: gradients.cache.override(other.gradients.cache),
-                             segmentControlStyleCache: segmentControlStyle.cache.override(other.segmentControlStyle.cache),
-                             sliderStyleCache: sliderStyle.cache.override(other.sliderStyle.cache),
-                             toggleStyleCache: toggleStyle.cache.override(other.toggleStyle.cache),
-                             using: configuration)
+                                colorCache: colors.cache.override(other.colors.cache),
+                                metricsCache: metrics.cache.override(other.metrics.cache),
+                                fontsCache: fonts.cache.override(other.fonts.cache),
+                                typographyCache: typography.cache.override(other.typography.cache),
+                                interactiveColorsCache: interactiveColors.cache.override(other.interactiveColors.cache),
+                                buttonStylesCache: buttonStyles.cache.override(other.buttonStyles.cache),
+                                shapeInformation: shapes.cache.override(other.shapes.cache),
+                                gradientsCache: gradients.cache.override(other.gradients.cache),
+                                segmentControlStyleCache: segmentControlStyle.cache.override(other.segmentControlStyle.cache),
+                                sliderStyleCache: sliderStyle.cache.override(other.sliderStyle.cache),
+                                toggleStyleCache: toggleStyle.cache.override(other.toggleStyle.cache),
+                                using: configuration)
     }
 }
 

--- a/SnappTheming/Sources/SnappTheming/Theme/ToggleStyle/SnappThemingToggleStyleConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/ToggleStyle/SnappThemingToggleStyleConfiguration.swift
@@ -10,11 +10,15 @@ import SwiftUI
 
 /// A configuration structure for defining toggle styles in the SnappTheming framework.
 public struct SnappThemingToggleStyleConfiguration {
+    // MARK: - Public Properties
+
     /// The fallback tint color for the toggle.
     public let fallbackTintColor: Color
 
     /// The fallback tint color for the toggle when it is disabled.
     public let fallbackDisabledTintColor: Color
+
+    // MARK: - Internal Properties
 
     let colors: SnappThemingColorDeclarations
     let colorFormat: SnappThemingColorFormat

--- a/SnappTheming/Sources/SnappTheming/Theme/ToggleStyle/SnappThemingToggleStyleRepresentation.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/ToggleStyle/SnappThemingToggleStyleRepresentation.swift
@@ -8,7 +8,26 @@
 import Foundation
 
 /// A representation of toggle style in the SnappTheming framework.
+///
+/// This struct defines the visual appearance of a toggle, including its tint color and
+/// the color used when the toggle is disabled. Each color is represented by a
+/// `SnappThemingToken` linked to a `SnappThemingColorRepresentation`.
 public struct SnappThemingToggleStyleRepresentation: Codable {
+    /// The tint color of the toggle when it is in its active state.
     public let tintColor: SnappThemingToken<SnappThemingColorRepresentation>
+
+    /// The tint color of the toggle when it is in its disabled state.
     public let disabledTintColor: SnappThemingToken<SnappThemingColorRepresentation>
+
+    /// Initializes a new instance of `SnappThemingToggleStyleRepresentation`.
+    /// - Parameters:
+    ///   - tintColor: The active tint color of the toggle.
+    ///   - disabledTintColor: The tint color of the toggle when it is disabled.
+    public init(
+        tintColor: SnappThemingToken<SnappThemingColorRepresentation>,
+        disabledTintColor: SnappThemingToken<SnappThemingColorRepresentation>
+    ) {
+        self.tintColor = tintColor
+        self.disabledTintColor = disabledTintColor
+    }
 }

--- a/SnappTheming/Sources/SnappTheming/Theme/Token/SnappThemingToken+SnappThemingInteractiveColorInformation.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Token/SnappThemingToken+SnappThemingInteractiveColorInformation.swift
@@ -1,5 +1,5 @@
 //
-//  SnappThemingToken+InteractiveColorInformation.swift
+//  SnappThemingToken+SnappThemingInteractiveColorInformation.swift
 //  SnappTheming
 //
 //  Created by Ilian Konchev on 3.12.24.
@@ -17,12 +17,12 @@ extension SnappThemingToken where Value == SnappThemingInteractiveColorInformati
         switch token {
         case .alias(let path):
             if path.component == "colors" {
-                self = .value(.init(.alias(path)))
+                self = .value(Value(.alias(path)))
             } else {
                 self = .alias(path)
             }
         case .value(let v):
-            self = .value(.init(.value(v)))
+            self = .value(Value(.value(v)))
         }
     }
 }

--- a/SnappTheming/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyConfiguration.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyConfiguration.swift
@@ -1,0 +1,19 @@
+//
+//  SnappThemingTypographyConfiguration.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+
+/// Configuration for resolving typography in the SnappTheming framework.
+public struct SnappThemingTypographyConfiguration {
+    /// Fallback font size to use when a specific typography size cannot be resolved.
+    let fallbackFontSize: CGFloat
+    /// A declaration of font-related theming configurations.
+    let fonts: SnappThemingFontDeclarations
+    /// A declaration of metric-related theming configurations.
+    let metrics: SnappThemingMetricDeclarations
+}
+

--- a/SnappTheming/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyDeclarations.swift
@@ -12,36 +12,9 @@ import SwiftUI
 /// Manages typography tokens, combining font and size. Provides full control over how text styles are applied in the app.
 public typealias SnappThemingTypographyDeclarations = SnappThemingDeclarations<SnappThemingTypographyRepresentation, SnappThemingTypographyConfiguration>
 
-/// Configuration for resolving typography in the SnappTheming framework.
-public struct SnappThemingTypographyConfiguration {
-    /// Fallback font size to use when a specific typography size cannot be resolved.
-    let fallbackFontSize: CGFloat
-    /// A declaration of font-related theming configurations.
-    let fonts: SnappThemingFontDeclarations
-    /// A declaration of metric-related theming configurations.
-    let metrics: SnappThemingMetricDeclarations
-}
-
-/// Resolver for typography in the SnappTheming framework.
-public struct SnappThemingTypographyResolver: Sendable {
-    /// Resolved `UIFont` for UIKit usage.
-    public let uiFont: UIFont
-    /// Resolved `Font` for SwiftUI usage.
-    public let font: Font
-
-    /// Initializes a typography resolver with a given font resolver and font size.
-    /// - Parameters:
-    ///   - resolver: The font resolver containing the font information.
-    ///   - fontSize: The size of the font to resolve.
-    public init(_ resolver: SnappThemingFontResolver, fontSize: CGFloat) {
-        self.uiFont = resolver.uiFont(size: fontSize)
-        self.font = resolver.font(size: fontSize)
-    }
-}
-
 extension SnappThemingDeclarations where DeclaredValue == SnappThemingTypographyRepresentation, Configuration == SnappThemingTypographyConfiguration {
     public init(
-        cache: [String: SnappThemingToken<SnappThemingTypographyRepresentation>]?,
+        cache: [String: SnappThemingToken<DeclaredValue>]?,
         configuration: SnappThemingParserConfiguration,
         fonts: SnappThemingFontDeclarations,
         metrics: SnappThemingMetricDeclarations
@@ -49,7 +22,7 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingTypography
         self.init(
             cache: cache,
             rootKey: .typography,
-            configuration: .init(
+            configuration: Configuration(
                 fallbackFontSize: configuration.fallbackTypographyFontSize,
                 fonts: fonts,
                 metrics: metrics
@@ -59,13 +32,13 @@ extension SnappThemingDeclarations where DeclaredValue == SnappThemingTypography
 
     public subscript(dynamicMember keyPath: String) -> SnappThemingTypographyResolver {
         guard
-            let representation: SnappThemingTypographyRepresentation = self[dynamicMember: keyPath],
+            let representation: DeclaredValue = self[dynamicMember: keyPath],
             let font = configuration.fonts.resolver.resolve(representation.font),
             let fontSize = configuration.metrics.resolver.resolve(representation.fontSize)
         else {
-            return .init(.system, fontSize: configuration.fallbackFontSize)
+            return SnappThemingTypographyResolver(.system, fontSize: configuration.fallbackFontSize)
         }
-        return .init(font.resolver, fontSize: fontSize.cgFloat)
+        return SnappThemingTypographyResolver(font.resolver, fontSize: fontSize.cgFloat)
     }
 
     public subscript(dynamicMember keyPath: String) -> UIFont {

--- a/SnappTheming/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyResolver.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyResolver.swift
@@ -1,0 +1,27 @@
+//
+//  SnappThemingTypographyResolver.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 20.01.2025.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+
+/// Resolver for typography in the SnappTheming framework.
+public struct SnappThemingTypographyResolver: Sendable {
+    /// Resolved `UIFont` for UIKit usage.
+    public let uiFont: UIFont
+    /// Resolved `Font` for SwiftUI usage.
+    public let font: Font
+
+    /// Initializes a typography resolver with a given font resolver and font size.
+    /// - Parameters:
+    ///   - resolver: The font resolver containing the font information.
+    ///   - fontSize: The size of the font to resolve.
+    public init(_ resolver: SnappThemingFontResolver, fontSize: CGFloat) {
+        self.uiFont = resolver.uiFont(size: fontSize)
+        self.font = resolver.font(size: fontSize)
+    }
+}

--- a/SnappTheming/Sources/SnappTheming/Theme/Util/SnappThemingDeclarations.swift
+++ b/SnappTheming/Sources/SnappTheming/Theme/Util/SnappThemingDeclarations.swift
@@ -108,10 +108,10 @@ public struct SnappThemingDeclarations<DeclaredValue, Configuration> where Decla
         }
 
         // Build the token path
-        let path = SnappThemingTokenPath(component: rootKey.rawValue, name: keyPath)
+        let tokenPath = SnappThemingTokenPath(component: rootKey.rawValue, name: keyPath)
 
         // Resolve the value using the resolver
-        guard let resolvedValue = resolver.resolve(.alias(path)) else {
+        guard let resolvedValue = resolver.resolve(.alias(tokenPath)) else {
             os_log(.debug, "Invalid access to keyPath '%@': Failed to resolve the value", keyPath)
             return nil
         }


### PR DESCRIPTION
- move abstractions to its own files
- check names and access controls
- replace `.init` to the type name for better readability
- add some comments and move some properties up
- added Example target(it was missed)