### PR TITLE
Documentation build warnings

### DIFF
--- a/Sources/SnappTheming/SnappTheming.docc/JSONSchema.md
+++ b/Sources/SnappTheming/SnappTheming.docc/JSONSchema.md
@@ -13,19 +13,10 @@ The object types have been categorized into two primary groups: foundation objec
 - [Colors](<doc:SnappThemingColorDeclarations>)
 - [Fonts](<doc:SnappThemingFontDeclarations>)
 - [Gradients](<doc:SnappThemingGradientDeclarations>)
-  - [Angular](<doc:SnappThemingGradientDeclarations#Angular-Gradient>) 
-  - [Linear](<doc:SnappThemingGradientDeclarations#Linear-Gradient>)
-  - [Radial](<doc:SnappThemingGradientDeclarations#Radial-Gradient>)
 - [Images](<doc:SnappThemingImageDeclarations>)
 - [Lottie Animations](<doc:SnappThemingAnimationDeclarations>)
 - [Metrics](<doc:SnappThemingMetricDeclarations>)
 - [Shapes](<doc:SnappThemingShapeDeclarations>)
-  - [Rectangle](<doc:SnappThemingShapeDeclarations#Rectangle>)
-  - [Ellipse](<doc:SnappThemingShapeDeclarations#Ellipse>)
-  - [Circle](<doc:SnappThemingShapeDeclarations#Circle>)
-  - [Capsule](<doc:SnappThemingShapeDeclarations#Capsule>)
-  - [Rounded rectangle](<doc:SnappThemingShapeDeclarations#Rounded-Rectangle>)
-  - [Uneven rouded rectangle](<doc:SnappThemingShapeDeclarations#Uneven-Rounded-Rectangle>)
 
 #### High-level objects
 

--- a/Sources/SnappTheming/Theme/Buttons/SnappThemingButtonStyle.swift
+++ b/Sources/SnappTheming/Theme/Buttons/SnappThemingButtonStyle.swift
@@ -44,7 +44,7 @@ public struct SnappThemingButtonStyle: ButtonStyle {
     ///   - textColor: The color used for the button's text.
     ///   - borderColor: The color used for the button's border.
     ///   - borderWidth: The width of the button's border.
-    ///   - shape: The shape type to apply to the button's border (e.g., rounded corners).
+    ///   - shapeType: The shape type to apply to the button's border (e.g., rounded corners).
     ///   - font: The font to apply to the button's label.
     public init(
         surfaceColor: SnappThemingInteractiveColor,


### PR DESCRIPTION
- update missed argument name
- remove `<doc:[TypeName]#[SubTypeName]>` references that causes warnings

# Warnings
 ![CleanShot 2025-02-11 at 14 35 57](https://github.com/user-attachments/assets/5778222c-b4b7-423b-aa71-50ade0e1c935)

# Updated documentation
| <img width="965" alt="Screenshot 2025-02-11 at 18 47 50" src="https://github.com/user-attachments/assets/df814a5e-8996-4964-a68d-1890d8867f26" /> | <img width="958" alt="Screenshot 2025-02-11 at 18 48 04" src="https://github.com/user-attachments/assets/b35168ff-6812-478a-8640-df0808acb020" /> |
| --- | --- |
