### PR TITLE
[WIP] - Fallback Logging Behavior

### DIFF
--- a/Example/Example/Example/Modules/Main/MainView.swift
+++ b/Example/Example/Example/Modules/Main/MainView.swift
@@ -38,7 +38,6 @@ struct MainView: View {
     @Environment(Theme.self) var theme
 
     var body: some View {
-        let _ = Self._printChanges()
         TabView(selection: $selectedTab) {
             ForEach(Tab.allCases) { tab in
                 tabContent(tab)

--- a/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationDeclarations.swift
+++ b/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationDeclarations.swift
@@ -44,7 +44,7 @@ where
         if let representation: DeclaredValue = self[dynamicMember: keyPath] {
             return representation.animation
         } else {
-            os_log(.debug, "Warning: Missing animation for key path '%@'. Using fallback animation.", keyPath)
+            runtimeWarning("Missing animation for key path '\(keyPath)'.")
             return .lottie(configuration.fallbackLottieAnimationData)
         }
     }

--- a/Sources/SnappTheming/Theme/Image/SnappThemingImageDeclarations.swift
+++ b/Sources/SnappTheming/Theme/Image/SnappThemingImageDeclarations.swift
@@ -52,7 +52,7 @@ where DeclaredValue == SnappThemingDataURI, Configuration == SnappThemingImageCo
         guard
             let representation: DeclaredValue = self[dynamicMember: keyPath]
         else {
-            os_log(.error, "Error resolving image with name: %@.", keyPath)
+            runtimeWarning("Failed resolving image with name: \(keyPath).")
             return configuration.fallbackImage
         }
 

--- a/Sources/SnappTheming/Theme/SnappThemingDeclaration.swift
+++ b/Sources/SnappTheming/Theme/SnappThemingDeclaration.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Ilian Konchev on 21.11.24.
 //
+
 import Foundation
 import OSLog
 

--- a/Sources/SnappTheming/Theme/Util/RuntimeWarning.swift
+++ b/Sources/SnappTheming/Theme/Util/RuntimeWarning.swift
@@ -1,0 +1,47 @@
+//
+//  RuntimeWarning.swift
+//  SnappTheming
+//
+//  Created by Oleksii Kolomiiets on 17.02.2025.
+//
+
+import Foundation
+import OSLog
+
+#if DEBUG
+    private func runningTests() -> Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil
+    }
+#endif
+
+internal func runtimeWarning(_ message: String) {
+    #if DEBUG
+        if runningTests() {
+            var info = Dl_info()
+            dladdr(
+                dlsym(
+                    dlopen(nil, RTLD_LAZY),
+                    """
+                    $s10Foundation15AttributeScopesO7SwiftUIE05swiftE0AcDE0D12UIAttributesVmvg
+                    """
+                ),
+                &info
+            )
+            // Find the warning in the Issue Navigator (⌘5) to view the full stack trace captured at the moment the warning was logged.
+            // Selecting element number '1' in the stack trace will take you to the exact location where the warning was triggered.
+            os_log(
+                .fault,
+                dso: info.dli_fbase,
+                log: OSLog(
+                    subsystem: "com.apple.runtime-issues",
+                    category: "SnappTheming"
+                ),
+                "%@", message
+            )
+        } else {
+            os_log(.debug, "%@", message)
+        }
+    #else
+        os_log(.debug, "%@", message)
+    #endif
+}


### PR DESCRIPTION
## ✨ This PR Will:
- add runtime warnings to highlight broken declarations

## 🎯 Purpose  
To detect potential JSON issues, we need runtime warnings for fallback logic declarations.

## 💻 Code Snippets
Place the runtime warning logic in a separate function and ensure it’s only triggered when the application is running in debug. Also, test shouldn’t trigger it.
```swift
#if DEBUG
    private func runningTests() -> Bool {
        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil
    }
#endif

internal func runtimeWarning(_ message: String) {
    #if DEBUG
        if runningTests() {
            var info = Dl_info()
            dladdr(
                dlsym(
                    dlopen(nil, RTLD_LAZY),
                    """
                    $s10Foundation15AttributeScopesO7SwiftUIE05swiftE0AcDE0D12UIAttributesVmvg
                    """
                ),
                &info
            )
            // Find the warning in the Issue Navigator (⌘5) to view the full stack trace captured at the moment the warning was logged.
            // Selecting element number '1' in the stack trace will take you to the exact location where the warning was triggered.
            os_log(
                .fault,
                dso: info.dli_fbase,
                log: OSLog(
                    subsystem: "com.apple.runtime-issues",
                    category: "SnappTheming"
                ),
                "%@", message
            )
        } else {
            os_log(.debug, "%@", message)
        }
    #else
        os_log(.debug, "%@", message)
    #endif
}

```
