### PR TITLE
Make representations available for initialization from code

### DIFF
--- a/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationRepresentation.swift
@@ -82,6 +82,10 @@ public struct SnappThemingAnimationRepresentation: Codable {
         }
     }
 
+    public init(animation: SnappThemingAnimationValue) {
+        self.animation = animation
+    }
+
     /// Encodes an instance of `SnappThemingAnimationRepresentation` to an encoder.
     ///
     /// - Parameter encoder: The encoder to encode to.

--- a/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Animations/SnappThemingAnimationRepresentation.swift
@@ -82,6 +82,9 @@ public struct SnappThemingAnimationRepresentation: Codable {
         }
     }
 
+    /// Initializes a `SnappThemingAnimationRepresentation` with a specific animation value.
+    ///
+    /// - Parameter animation: The `SnappThemingAnimationValue` to represent.
     public init(animation: SnappThemingAnimationValue) {
         self.animation = animation
     }

--- a/Sources/SnappTheming/Theme/Color/SnappThemingDynamicColor.swift
+++ b/Sources/SnappTheming/Theme/Color/SnappThemingDynamicColor.swift
@@ -20,6 +20,11 @@ public struct SnappThemingDynamicColor: Codable {
     private let light: String
     private let dark: String
 
+    /// Initializes a `SnappThemingDynamicColor` with separate color string values for light and dark appearances.
+    ///
+    /// - Parameters:
+    ///   - light: The hexadecimal string representation of the color for light mode.
+    ///   - dark: The hexadecimal string representation of the color for dark mode.
     public init(light: String, dark: String) {
         self.light = light
         self.dark = dark

--- a/Sources/SnappTheming/Theme/Color/SnappThemingDynamicColor.swift
+++ b/Sources/SnappTheming/Theme/Color/SnappThemingDynamicColor.swift
@@ -20,6 +20,11 @@ public struct SnappThemingDynamicColor: Codable {
     private let light: String
     private let dark: String
 
+    public init(light: String, dark: String) {
+        self.light = light
+        self.dark = dark
+    }
+
     #if canImport(UIKit)
         /// Returns a `UIColor` for the current user interface style (light or dark mode).
         /// - Parameter colorFormat: The color format to use (e.g., ARGB, RGBA).

--- a/Sources/SnappTheming/Theme/Font/SnappThemingFontInformation.swift
+++ b/Sources/SnappTheming/Theme/Font/SnappThemingFontInformation.swift
@@ -14,6 +14,11 @@ public struct SnappThemingFontInformation: Codable, Hashable {
 
     /// The data source for the font, typically encoded as a data URI. This property is optional and will be `nil` if the font is either bundled within the app or provided by the system.
     public let source: SnappThemingDataURI?
+
+    public init(postScriptName: String, source: SnappThemingDataURI?) {
+        self.postScriptName = postScriptName
+        self.source = source
+    }
 }
 
 extension SnappThemingFontInformation {

--- a/Sources/SnappTheming/Theme/Font/SnappThemingFontInformation.swift
+++ b/Sources/SnappTheming/Theme/Font/SnappThemingFontInformation.swift
@@ -15,6 +15,12 @@ public struct SnappThemingFontInformation: Codable, Hashable {
     /// The data source for the font, typically encoded as a data URI. This property is optional and will be `nil` if the font is either bundled within the app or provided by the system.
     public let source: SnappThemingDataURI?
 
+    /// Initializes `SnappThemingFontInformation` with the PostScript name and an optional data source.
+    ///
+    /// - Parameters:
+    ///   - postScriptName: The PostScript name of the font.
+    ///   - source: An optional `SnappThemingDataURI` representing the font's data source.
+    ///             This can be `nil` if the font is system-provided or bundled.
     public init(postScriptName: String, source: SnappThemingDataURI?) {
         self.postScriptName = postScriptName
         self.source = source

--- a/Sources/SnappTheming/Theme/Gradient/Gradients/AngularGradient/SnappThemingAngularGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/Gradients/AngularGradient/SnappThemingAngularGradientRepresentation.swift
@@ -20,6 +20,18 @@ public struct SnappThemingAngularGradientRepresentation {
 
     /// The ending angle of the gradient, represented as a theming token.
     public let endAngle: SnappThemingToken<Double>
+
+    public init(
+        colors: [SnappThemingToken<SnappThemingColorRepresentation>],
+        center: SnappThemingUnitPointWrapper,
+        startAngle: SnappThemingToken<Double>,
+        endAngle: SnappThemingToken<Double>
+    ) {
+        self.colors = colors
+        self.center = center
+        self.startAngle = startAngle
+        self.endAngle = endAngle
+    }
 }
 
 extension SnappThemingAngularGradientRepresentation: SnappThemingGradientProviding {

--- a/Sources/SnappTheming/Theme/Gradient/Gradients/AngularGradient/SnappThemingAngularGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/Gradients/AngularGradient/SnappThemingAngularGradientRepresentation.swift
@@ -21,6 +21,13 @@ public struct SnappThemingAngularGradientRepresentation {
     /// The ending angle of the gradient, represented as a theming token.
     public let endAngle: SnappThemingToken<Double>
 
+    /// Initializes a `SnappThemingAngularGradientRepresentation` with the specified properties.
+    ///
+    /// - Parameters:
+    ///   - colors: An array of `SnappThemingToken` objects, each representing a color in the gradient.
+    ///   - center: A `SnappThemingUnitPointWrapper` defining the center point of the gradient.
+    ///   - startAngle: A `SnappThemingToken<Double>` representing the starting angle of the gradient in degrees.
+    ///   - endAngle: A `SnappThemingToken<Double>` representing the ending angle of the gradient in degrees.
     public init(
         colors: [SnappThemingToken<SnappThemingColorRepresentation>],
         center: SnappThemingUnitPointWrapper,

--- a/Sources/SnappTheming/Theme/Gradient/Gradients/LinearGradient/SnappThemingLinearGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/Gradients/LinearGradient/SnappThemingLinearGradientRepresentation.swift
@@ -19,6 +19,16 @@ public struct SnappThemingLinearGradientRepresentation: Codable {
 
     /// The ending point of the gradient.
     public let endPoint: SnappThemingUnitPointWrapper
+
+    public init(
+        colors: [SnappThemingToken<SnappThemingColorRepresentation>],
+        startPoint: SnappThemingUnitPointWrapper,
+        endPoint: SnappThemingUnitPointWrapper
+    ) {
+        self.colors = colors
+        self.startPoint = startPoint
+        self.endPoint = endPoint
+    }
 }
 
 extension SnappThemingLinearGradientRepresentation: SnappThemingGradientProviding {

--- a/Sources/SnappTheming/Theme/Gradient/Gradients/LinearGradient/SnappThemingLinearGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/Gradients/LinearGradient/SnappThemingLinearGradientRepresentation.swift
@@ -20,6 +20,12 @@ public struct SnappThemingLinearGradientRepresentation: Codable {
     /// The ending point of the gradient.
     public let endPoint: SnappThemingUnitPointWrapper
 
+    /// Initializes a `SnappThemingLinearGradientRepresentation` with the specified properties.
+    ///
+    /// - Parameters:
+    ///   - colors: An array of `SnappThemingToken` objects, each representing a color in the gradient.
+    ///   - startPoint: A `SnappThemingUnitPointWrapper` defining the starting point of the gradient.
+    ///   - endPoint: A `SnappThemingUnitPointWrapper` defining the ending point of the gradient.
     public init(
         colors: [SnappThemingToken<SnappThemingColorRepresentation>],
         startPoint: SnappThemingUnitPointWrapper,

--- a/Sources/SnappTheming/Theme/Gradient/Gradients/RadialGradient/SnappThemingRadialGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/Gradients/RadialGradient/SnappThemingRadialGradientRepresentation.swift
@@ -25,6 +25,13 @@ public struct SnappThemingRadialGradientRepresentation: Codable {
     /// The ending radius of the gradient, represented as a theming token.
     public let endRadius: SnappThemingToken<Double>
 
+    /// Initializes a `SnappThemingRadialGradientRepresentation` with the specified properties.
+    ///
+    /// - Parameters:
+    ///   - colors: An array of `SnappThemingToken` objects, each representing a color in the gradient.
+    ///   - center: A `SnappThemingUnitPointWrapper` defining the center point of the gradient.
+    ///   - startRadius: A `SnappThemingToken<Double>` representing the starting radius of the gradient.
+    ///   - endRadius: A `SnappThemingToken<Double>` representing the ending radius of the gradient.
     public init(
         colors: [SnappThemingToken<SnappThemingColorRepresentation>],
         center: SnappThemingUnitPointWrapper,

--- a/Sources/SnappTheming/Theme/Gradient/Gradients/RadialGradient/SnappThemingRadialGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/Gradients/RadialGradient/SnappThemingRadialGradientRepresentation.swift
@@ -24,6 +24,18 @@ public struct SnappThemingRadialGradientRepresentation: Codable {
 
     /// The ending radius of the gradient, represented as a theming token.
     public let endRadius: SnappThemingToken<Double>
+
+    public init(
+        colors: [SnappThemingToken<SnappThemingColorRepresentation>],
+        center: SnappThemingUnitPointWrapper,
+        startRadius: SnappThemingToken<Double>,
+        endRadius: SnappThemingToken<Double>
+    ) {
+        self.colors = colors
+        self.center = center
+        self.startRadius = startRadius
+        self.endRadius = endRadius
+    }
 }
 
 extension SnappThemingRadialGradientRepresentation: SnappThemingGradientProviding {

--- a/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientRepresentation.swift
@@ -68,6 +68,10 @@ public struct SnappThemingGradientRepresentation: Codable {
         }
     }
 
+    /// Initializes a `SnappThemingGradientRepresentation` with a specific gradient-providing configuration.
+    ///
+    /// - Parameter configuration: An object conforming to `SnappThemingGradientProviding`
+    ///                            that defines the gradient's appearance and behavior.
     public init(configuration: any SnappThemingGradientProviding) {
         self.configuration = configuration
     }

--- a/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Gradient/SnappThemingGradientRepresentation.swift
@@ -68,6 +68,10 @@ public struct SnappThemingGradientRepresentation: Codable {
         }
     }
 
+    public init(configuration: any SnappThemingGradientProviding) {
+        self.configuration = configuration
+    }
+
     /// Encodes the shape style representation into the provided encoder.
     ///
     /// This method encodes the `configuration` property (which contains the shape style)

--- a/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyRepresentation.swift
@@ -13,4 +13,12 @@ public struct SnappThemingTypographyRepresentation: Codable {
     public let font: SnappThemingToken<SnappThemingFontInformation>
     /// A token that represents the font size.
     public let fontSize: SnappThemingToken<Double>
+
+    public init(
+        font: SnappThemingToken<SnappThemingFontInformation>,
+        fontSize: SnappThemingToken<Double>
+    ) {
+        self.font = font
+        self.fontSize = fontSize
+    }
 }

--- a/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyRepresentation.swift
+++ b/Sources/SnappTheming/Theme/Typography/SnappThemingTypographyRepresentation.swift
@@ -14,6 +14,11 @@ public struct SnappThemingTypographyRepresentation: Codable {
     /// A token that represents the font size.
     public let fontSize: SnappThemingToken<Double>
 
+    /// Initializes a `SnappThemingTypographyRepresentation` with font and font size tokens.
+    ///
+    /// - Parameters:
+    ///   - font: A `SnappThemingToken<SnappThemingFontInformation>` representing the font.
+    ///   - fontSize: A `SnappThemingToken<Double>` representing the font size.
     public init(
         font: SnappThemingToken<SnappThemingFontInformation>,
         fontSize: SnappThemingToken<Double>

--- a/Sources/SnappTheming/Theme/Util/SnappThemingDataURI.swift
+++ b/Sources/SnappTheming/Theme/Util/SnappThemingDataURI.swift
@@ -35,6 +35,12 @@ public struct SnappThemingDataURI: Sendable, Hashable {
     /// The raw data represented by the data URI.
     public let data: Data
 
+    /// Initializes a `SnappThemingDataURI` with the specified type, encoding, and data.
+    ///
+    /// - Parameters:
+    ///   - type: The `UTType` representing the data's type.
+    ///   - encoding: The `Encoding` (e.g., `.base64`) used for the data.
+    ///   - data: The raw `Data`.
     public init(type: UTType, encoding: Encoding, data: Data) {
         self.type = type
         self.encoding = encoding

--- a/Sources/SnappTheming/Theme/Util/SnappThemingDataURI.swift
+++ b/Sources/SnappTheming/Theme/Util/SnappThemingDataURI.swift
@@ -34,6 +34,12 @@ public struct SnappThemingDataURI: Sendable, Hashable {
 
     /// The raw data represented by the data URI.
     public let data: Data
+
+    public init(type: UTType, encoding: Encoding, data: Data) {
+        self.type = type
+        self.encoding = encoding
+        self.data = data
+    }
 }
 
 extension SnappThemingDataURI: Codable {

--- a/Sources/SnappTheming/Theme/Util/SnappThemingUnitPointWrapper.swift
+++ b/Sources/SnappTheming/Theme/Util/SnappThemingUnitPointWrapper.swift
@@ -18,6 +18,9 @@ public struct SnappThemingUnitPointWrapper {
     /// It can represent values like `.center`, `.topLeading`, etc., based on the theme configuration.
     public let value: UnitPoint
 
+    /// Initializes a `SnappThemingUnitPointWrapper` with a specific `UnitPoint` value.
+    ///
+    /// - Parameter value: The `UnitPoint` to wrap.
     public init(value: UnitPoint) {
         self.value = value
     }

--- a/Sources/SnappTheming/Theme/Util/SnappThemingUnitPointWrapper.swift
+++ b/Sources/SnappTheming/Theme/Util/SnappThemingUnitPointWrapper.swift
@@ -17,6 +17,10 @@ public struct SnappThemingUnitPointWrapper {
     ///
     /// It can represent values like `.center`, `.topLeading`, etc., based on the theme configuration.
     public let value: UnitPoint
+
+    public init(value: UnitPoint) {
+        self.value = value
+    }
 }
 
 extension SnappThemingUnitPointWrapper: Codable {


### PR DESCRIPTION
#### ✨ This PR Will:
Make initializers public for:
- `SnappThemingAnimationRepresentation`
- `SnappThemingDynamicColor`
- `SnappThemingFontInformation`
- `SnappThemingAngularGradientRepresentation`
- `SnappThemingLinearGradientRepresentation`
- `SnappThemingRadialGradientRepresentation`
- `SnappThemingGradientRepresentation`
- `SnappThemingTypographyRepresentation`
- `SnappThemingDataURI`
- `SnappThemingUnitPointWrapper`

#### 🎯 Purpose  
This changes will allow users to build `SnappThemingDeclaration` programmatically.

#### 🧪 Unit Tests 
No new tests were needed because there is no new functionality introduced.
